### PR TITLE
docs: fixes incorrect request param and adds new example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,33 @@ import { MergeClient, Merge } from '@mergeapi/merge-node-client';
 
 const merge = new MergeClient({
   apiKey: 'YOUR_API_KEY',
-  accountToken: 'YOUR_ACCOUNT_TOKEN',
+  // `accountToken` may be omitted if necessary (e.g., during the initial Link session)
+  accountToken: 'YOUR_ACCOUNT_TOKEN', 
 });
 
 const linkTokenResponse = await merge.ats.linkToken.create({
     endUserEmailAddress: "john.smith@gmail.com",
     endUserOrganizationName: "acme",
-    endUserOrganizationId: "1234",
+    endUserOriginId: "1234",
     categories: [Merge.ats.CategoriesEnum.ATS],
     linkExpiryMins: 30,
 });
 
 console.log("Created link token", linkTokenResponse.linkToken)
+```
+
+### Retrieve Account Token Using Public Token
+
+```ts
+import { MergeClient, Merge } from '@mergeapi/merge-node-client';
+
+const merge = new MergeClient({
+  apiKey: 'YOUR_API_KEY'
+});
+
+const accountTokenResponse = await merge.ats.accountToken.retrieve(publicToken)
+
+console.log("Retrieved account token", accountTokenResponse.accountToken)
 ```
 
 ### Get Employee


### PR DESCRIPTION
Hi there, was recently going through the `link account` process for the first time recently and I wanted to contribute a few minor changes for the README. One of the property names were slightly off `endUserOrganizationId -> endUserOriginId`, so changed that. 

Also added an example and in-line comment to make clear that the client can be initialized/send requests without the `accountToken`, and is in fact necessary in some cases. The typings were clear so it wasn't difficult to figure out, but I think clarifying will be helpful when someone is familiarizing themselves with Merge's frontend -> backend auth flow. 

Thank you in advance for considering these changes! 