### PR TITLE
chore: bump version to 4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mergeapi/merge-node-client",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "4.0.3";
+export const SDK_VERSION = "4.0.4";


### PR DESCRIPTION
## Summary

Bumps the SDK version from `4.0.3` to `4.0.4` in preparation for release.

This release ships the fix from #158 (resolves #157): array query parameters (e.g. `expand`) are now serialized as comma-separated values (`?expand=groups,work_location`) instead of repeated params, so all values are sent to the API instead of being silently dropped.

## Changes
- `package.json`: `4.0.3` → `4.0.4`
- `src/version.ts`: `SDK_VERSION` `4.0.3` → `4.0.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)